### PR TITLE
Miscellaneous fixes to the bootstrap colorpicker

### DIFF
--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -137,9 +137,7 @@
 		this.isInput = this.element.is('input');
 		this.component = this.element.is('.color') ? this.element.find('.add-on') : false;
 		
-		this.picker = $(CPGlobal.template)
-							.appendTo('body')
-							.on('mousedown', $.proxy(this.mousedown, this));
+		this.picker = $(CPGlobal.template).on('mousedown', $.proxy(this.mousedown, this));
 		
 		if (this.isInput) {
 			this.element.on({

--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -175,6 +175,7 @@
 		constructor: Colorpicker,
 		
 		show: function(e) {
+			this.picker.appendTo('body');
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();
@@ -237,10 +238,15 @@
 		},
 		
 		place: function(){
-			var offset = this.component ? this.component.offset() : this.element.offset();
+			var zIndex = parseInt(this.element.parents().filter(function() {
+							return $(this).css('z-index') != 'auto';
+						}).first().css('z-index'))+10;
+			var offset = this.component ? this.component.parent().offset() : this.element.offset();
+			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(true);
 			this.picker.css({
-				top: offset.top + this.height,
-				left: offset.left
+				top: offset.top + height,
+				left: offset.left,
+				zIndex: zIndex
 			});
 		},
 		

--- a/js/bootstrap-colorpicker.js
+++ b/js/bootstrap-colorpicker.js
@@ -216,7 +216,7 @@
 		},
 		
 		hide: function(){
-			this.picker.hide();
+			this.picker.hide().detach();
 			$(window).off('resize', this.place);
 			if (!this.isInput) {
 				$(document).off({

--- a/less/colorpicker.less
+++ b/less/colorpicker.less
@@ -18,7 +18,7 @@
 		height: 5px;
 		width: 5px;
 		border: 1px solid #000;
-		.border-radius();
+		.border-radius(5px);
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -28,7 +28,7 @@
 			height: 5px;
 			width: 5px;
 			border: 1px solid #fff;
-			.border-radius();
+			.border-radius(5px);
 		}
 	}
 }


### PR DESCRIPTION
1. The color picker won't display properly in a dialog box.  Ported code from bootstrap-datepicker to remedy.  The color picker won't append to the body until show is called.  It will detach itself on hide.
2. The colorpicker.less wouldn't even compile for me with bootstrap 2.3.1.  .border-radius couldn't take a no-arg function call.  I set the border-radius defaults to 5px.
